### PR TITLE
fix: manual copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # NEVER EDIT MANUALLY
 # https://copier.readthedocs.io/en/stable/updating/#never-change-the-answers-file-manually
 
-_commit: 0.4.2-rc.2
+_commit: 0.4.3-rc.1
 _src_path: gh:launchbynttdata/launch-terraform-skeleton

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-automated-approvals.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-automated-approvals.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pull-request-check-terraform.yml
+++ b/.github/workflows/pull-request-check-terraform.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
       id-token: write
       statuses: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
     with:
       auth_method: ${{ startsWith(github.event.repository.name, 'tf-aws') && 'aws' ||
         startsWith(github.event.repository.name, 'tf-az') && 'azure' || '' }}

--- a/.github/workflows/pull-request-dependabot-automerge.yml
+++ b/.github/workflows/pull-request-dependabot-automerge.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-dependabot-automerge.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-dependabot-automerge.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -11,4 +11,4 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-conventional-commit-title.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-conventional-commit-title.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd

--- a/.github/workflows/pull-request-precommit-checks.yml
+++ b/.github/workflows/pull-request-precommit-checks.yml
@@ -68,7 +68,7 @@ jobs:
       - id: set-status-check
         name: Set Status Check
         if: always()
-        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@1dd2a82736c07845531e3c10d18d75b7d71f3525
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
         with:
           check_name: "Pre-Commit Checks"
           status: ${{ steps.pre-commit.outcome == 'success' && 'success' ||

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,5 +14,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/update-from-skeleton.yml
+++ b/.github/workflows/update-from-skeleton.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-update-from-skeleton.yml@1dd2a82736c07845531e3c10d18d75b7d71f3525
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-update-from-skeleton.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
     with:
       recopy: ${{ github.event.inputs.recopy == 'true' }}
     secrets: inherit # pragma: allowlist secret

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-*.tf       @launchbynttdata/terraform-administrators
-tests      @launchbynttdata/terraform-administrators
-examples   @launchbynttdata/terraform-administrators
+*          @launchbynttdata/terraform-administrators

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -6,17 +6,13 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
-## Providers
-
-No providers.
-
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
-| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.0 |
 | <a name="module_container_registry"></a> [container\_registry](#module\_container\_registry) | terraform.registry.launch.nttdata.com/module_primitive/container_registry/azurerm | ~> 2.0 |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.0 |
+| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
 | <a name="module_scope_map"></a> [scope\_map](#module\_scope\_map) | ../.. | n/a |
 
 ## Resources
@@ -27,23 +23,23 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_resource_names_map"></a> [resource\_names\_map](#input\_resource\_names\_map) | A map of key to resource\_name that will be used by tf-launch-module\_library-resource\_name to generate resource names | <pre>map(object({<br/>    name       = string<br/>    max_length = optional(number, 60)<br/>    region     = optional(string, "eastus2")<br/>  }))</pre> | <pre>{<br/>  "acr": {<br/>    "name": "acr"<br/>  },<br/>  "rg": {<br/>    "name": "rg"<br/>  },<br/>  "scope_map": {<br/>    "name": "sm"<br/>  }<br/>}</pre> | no |
-| <a name="input_resource_names_strategy"></a> [resource\_names\_strategy](#input\_resource\_names\_strategy) | Strategy to use for generating resource names, taken from the outputs of the naming module, e.g. 'standard', 'minimal\_random\_suffix', 'dns\_compliant\_standard', etc. This example forces the 'minimal\_random\_suffix\_without\_any\_separators' strategy for the ACR and scope map, as those names require alphanumeric characters only. | `string` | `"minimal_random_suffix"` | no |
-| <a name="input_logical_product_family"></a> [logical\_product\_family](#input\_logical\_product\_family) | (Required) Name of the product family for which the resource is created.<br/>    Example: org\_name, department\_name. | `string` | `"launch"` | no |
-| <a name="input_logical_product_service"></a> [logical\_product\_service](#input\_logical\_product\_service) | (Required) Name of the product service for which the resource is created.<br/>    For example, backend, frontend, middleware etc. | `string` | `"example"` | no |
+| <a name="input_actions"></a> [actions](#input\_actions) | A list of actions to attach to the scope map. Actions are comprised of <resource\_type>/<resource\_name>/<action>, where <resource\_type> is e.g 'repositories', <resource\_name> is either the name or a wildcard, and <action> is one of 'content/delete', 'content/read', 'content/write', 'metadata/read', 'metadata/write'. | `list(string)` | n/a | yes |
 | <a name="input_class_env"></a> [class\_env](#input\_class\_env) | (Required) Environment where resource is going to be deployed. For example: dev, qa, uat | `string` | `"sandbox"` | no |
 | <a name="input_instance_env"></a> [instance\_env](#input\_instance\_env) | Number that represents the instance of the environment. | `number` | `0` | no |
 | <a name="input_instance_resource"></a> [instance\_resource](#input\_instance\_resource) | Number that represents the instance of the resource. | `number` | `0` | no |
+| <a name="input_logical_product_family"></a> [logical\_product\_family](#input\_logical\_product\_family) | (Required) Name of the product family for which the resource is created.<br/>    Example: org\_name, department\_name. | `string` | `"launch"` | no |
+| <a name="input_logical_product_service"></a> [logical\_product\_service](#input\_logical\_product\_service) | (Required) Name of the product service for which the resource is created.<br/>    For example, backend, frontend, middleware etc. | `string` | `"example"` | no |
+| <a name="input_resource_names_map"></a> [resource\_names\_map](#input\_resource\_names\_map) | A map of key to resource\_name that will be used by tf-launch-module\_library-resource\_name to generate resource names | <pre>map(object({<br/>    name       = string<br/>    max_length = optional(number, 60)<br/>    region     = optional(string, "eastus2")<br/>  }))</pre> | <pre>{<br/>  "acr": {<br/>    "name": "acr"<br/>  },<br/>  "rg": {<br/>    "name": "rg"<br/>  },<br/>  "scope_map": {<br/>    "name": "sm"<br/>  }<br/>}</pre> | no |
+| <a name="input_resource_names_strategy"></a> [resource\_names\_strategy](#input\_resource\_names\_strategy) | Strategy to use for generating resource names, taken from the outputs of the naming module, e.g. 'standard', 'minimal\_random\_suffix', 'dns\_compliant\_standard', etc. This example forces the 'minimal\_random\_suffix\_without\_any\_separators' strategy for the ACR and scope map, as those names require alphanumeric characters only. | `string` | `"minimal_random_suffix"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources. | `map(string)` | `{}` | no |
-| <a name="input_actions"></a> [actions](#input\_actions) | A list of actions to attach to the scope map. Actions are comprised of <resource\_type>/<resource\_name>/<action>, where <resource\_type> is e.g 'repositories', <resource\_name> is either the name or a wildcard, and <action> is one of 'content/delete', 'content/read', 'content/write', 'metadata/read', 'metadata/write'. | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_container_registry_name"></a> [container\_registry\_name](#output\_container\_registry\_name) | n/a |
 | <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
-| <a name="output_container_registry_name"></a> [container\_registry\_name](#output\_container\_registry\_name) | n/a |
 | <a name="output_scope_map_id"></a> [scope\_map\_id](#output\_scope\_map\_id) | n/a |
 | <a name="output_scope_map_name"></a> [scope\_map\_name](#output\_scope\_map\_name) | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
This is one of the repos that took a bad workflow version and needs manual intervention. There are probably a few more of these to clean up, but the procedure from `main` is to run `pre-commit install` then `copier update --trust` and branch/add/commit/push, fixing anything detected by pre-commit.